### PR TITLE
Resolve Sage mapping issue

### DIFF
--- a/src/Factories/CustomerFactory.php
+++ b/src/Factories/CustomerFactory.php
@@ -52,18 +52,20 @@ class CustomerFactory
         $this->setTelephone(($this->order->billingAddress->mobile ?? $this->order->billingAddress->phone) ?? '');
 
         $this->setAddress('address', [
-            1 => (string) $this->order->billingAddress->line_1,
-            2 => (string) $this->order->billingAddress->line_2,
-            4 => (string) $this->order->billingAddress->city,
-            5 => (string) $this->order->billingAddress->postcode
+            1 => (string) $this->order->billingAddress->line_1, // Street 1
+            2 => (string) $this->order->billingAddress->line_2, // Street 2
+            3 => (string) $this->order->billingAddress->city, // Town
+            // 4 => // County
+            5 => (string) $this->order->billingAddress->postcode // Postcode
         ]);
 
         if ($this->order->shippingAddress) {
             $this->setAddress('deliveryAddress', [
-                1 => (string) $this->order->shippingAddress->line_1,
-                2 => (string) $this->order->shippingAddress->line_2,
-                4 => (string) $this->order->shippingAddress->city,
-                5 => (string) $this->order->shippingAddress->postcode
+                1 => (string) $this->order->shippingAddress->line_1, // Street 1
+                2 => (string) $this->order->shippingAddress->line_2, // Street 2
+                3 => (string) $this->order->shippingAddress->city, // Town
+                // 4 => // County
+                5 => (string) $this->order->shippingAddress->postcode // Postcode
             ]);
         }
 

--- a/src/Factories/SalesOrderFactory.php
+++ b/src/Factories/SalesOrderFactory.php
@@ -49,32 +49,36 @@ class SalesOrderFactory
         $this->sales['orderDate'] = $this->order->ordered_at->format('d/m/Y');
 
         $this->setContactName($this->order->billingAddress->fullName);
+        $this->setDeliveryName($this->order->shippingAddress->fullName);
         $this->setTelephone(($this->order->billingAddress->mobile ?? $this->order->billingAddress->phone) ?? '');
 
         $this->setAddress('address', [
-            1 => (string) $this->order->billingAddress->line_1,
-            2 => (string) $this->order->billingAddress->line_2,
-            4 => (string) $this->order->billingAddress->city,
-            5 => (string) $this->order->billingAddress->postcode
+            1 => (string) $this->order->billingAddress->line_1, // Street 1
+            2 => (string) $this->order->billingAddress->line_2, // Street 2
+            3 => (string) $this->order->billingAddress->city, // Town
+            //4 => // County
+            5 => (string) $this->order->billingAddress->postcode // Postcode
         ]);
 
         // Check for gift vouchers (as they don't have shipping)
         if ($this->order->shippingAddress) {
             $this->setAddress('delAddress', [
-                1 => (string) $this->order->shippingAddress->line_1,
-                2 => (string) $this->order->shippingAddress->line_2,
-                4 => (string) $this->order->shippingAddress->city,
-                5 => (string) $this->order->shippingAddress->postcode
+                1 => (string) $this->order->shippingAddress->line_1, // Street 1
+                2 => (string) $this->order->shippingAddress->line_2, // Street 2
+                3 => (string) $this->order->shippingAddress->city, // Town
+                //4 => // County
+                5 => (string) $this->order->shippingAddress->postcode // Postcode
             ]);
 
             $this->sales['carrNet'] = round($this->order->shipping / 100, 2);
             $this->sales['carrTax'] = round($this->order->shipping_tax / 100, 2);
         } else {
             $this->setAddress('delAddress', [
-                1 => (string) $this->order->billingAddress->line_1,
-                2 => (string) $this->order->billingAddress->line_2,
-                4 => (string) $this->order->billingAddress->city,
-                5 => (string) $this->order->billingAddress->postcode
+                1 => (string) $this->order->billingAddress->line_1, // Street 1
+                2 => (string) $this->order->billingAddress->line_2, // Street 2
+                3 => (string) $this->order->billingAddress->city, // Town
+                //4 => // County
+                5 => (string) $this->order->billingAddress->postcode // Postcode
             ]);
         }
 
@@ -115,6 +119,16 @@ class SalesOrderFactory
     {
         if (strlen($name) <= 30) {
             $this->sales['contactName'] = $name;
+        }
+    }
+
+    /**
+     * Validate and set the contacts name.
+     */
+    protected function setDeliveryName(string $name): void
+    {
+        if (strlen($name) <= 30) {
+            $this->sales['delName'] = $name;
         }
     }
 


### PR DESCRIPTION
## Description

Adjusted the format of how we provide delivery addresses to Sage. Currently we are providing Town/City in address4/deliveryAddress4, however this is mapped to the County in Sage so the formatting is incorrect. I've added comments explaining exactly what each line of the address is mapped too in Sage.

Also added in customer name for delivery address as per customer request.

https://projects.techquity.co.uk/desk/tickets/5922096/messages

---
## Associated PR
N/A

---
## Checklist

- [ ] Changes have been tested in Development with no issues
- [ ] I have tested the checkout process on the Development site
- [ ] I have tested the changes on multiple browsers / devices (if applicable)

---



