### PR TITLE
Resolve setTelephone typo

### DIFF
--- a/src/Factories/CustomerFactory.php
+++ b/src/Factories/CustomerFactory.php
@@ -130,7 +130,7 @@ class CustomerFactory
      */
     protected function setTelephone(string $telephone): void
     {
-        if (strlen($telephone) >= 30) {
+        if (strlen($telephone) <= 30) {
             $this->customer['telephone'] = $telephone;
         }
     }
@@ -197,7 +197,7 @@ class CustomerFactory
             }
 
             if (setting('sage_50.debug_mode')) {
-                Log::debug('Sage Order', [
+                Log::debug('Sage Customer', [
                     'integration' => 'sage 50',
                     'request' => $this->customer,
                     'response' => $response

--- a/src/Factories/SalesOrderFactory.php
+++ b/src/Factories/SalesOrderFactory.php
@@ -221,7 +221,7 @@ class SalesOrderFactory
             $this->order->additional('sage_order_ref', $response['response']);
 
             if (setting('sage_50.debug_mode')) {
-                Log::debug('Sage Customer', [
+                Log::debug('Sage Order', [
                     'integration' => 'sage 50',
                     'request' => $this->sales,
                     'response' => $response


### PR DESCRIPTION
## Description

Customer telephone not populating in Sage, the reason is we only set this if the telephone is greater than or equal to 30 characters, when it should be less than or equal. Also resolved an issue with the logs being named incorrectly.
https://projects.techquity.co.uk/desk/tickets/5946292/messages

---
## Associated PR
N/A

---
## Checklist
N/A

---



