### PR TITLE
Resolve error setting delivery name

### DIFF
--- a/src/Factories/SalesOrderFactory.php
+++ b/src/Factories/SalesOrderFactory.php
@@ -49,7 +49,6 @@ class SalesOrderFactory
         $this->sales['orderDate'] = $this->order->ordered_at->format('d/m/Y');
 
         $this->setContactName($this->order->billingAddress->fullName);
-        $this->setDeliveryName($this->order->shippingAddress->fullName);
         $this->setTelephone(($this->order->billingAddress->mobile ?? $this->order->billingAddress->phone) ?? '');
 
         $this->setAddress('address', [
@@ -70,6 +69,8 @@ class SalesOrderFactory
                 5 => (string) $this->order->shippingAddress->postcode // Postcode
             ]);
 
+            $this->setDeliveryName($this->order->shippingAddress->fullName);
+
             $this->sales['carrNet'] = round($this->order->shipping / 100, 2);
             $this->sales['carrTax'] = round($this->order->shipping_tax / 100, 2);
         } else {
@@ -80,6 +81,8 @@ class SalesOrderFactory
                 //4 => // County
                 5 => (string) $this->order->billingAddress->postcode // Postcode
             ]);
+
+            $this->setDeliveryName($this->order->billingAddress->fullName);
         }
 
         //this->sales['netValueDiscountAmount'] = round($this->order->discount / 100, 2);


### PR DESCRIPTION
## Description

If the shipping address isn't set, sending orders to Sage fails as we're trying to access the fullName attribute of an object that doesn't exist. Re-arranged the code so we only attempt to set the delivery name with the shipping address name if we have a shipping address, otherwise use the billing address name.

https://projects.techquity.co.uk/desk/tickets/6043509/messages

---
## Associated PR
N/A

---
## Checklist
N/A

- [ ] Changes have been tested in Development with no issues
- [ ] I have tested the checkout process on the Development site
- [ ] I have tested the changes on multiple browsers / devices (if applicable)

---



