### PR TITLE
Add setting to remove attribute name

### DIFF
--- a/src/Factories/SalesOrderFactory.php
+++ b/src/Factories/SalesOrderFactory.php
@@ -179,10 +179,17 @@ class SalesOrderFactory
                 $extend = $this->extendItem($item);
             }
 
-            $options = collect($item->options)
-                ->filter(fn ($item) => isset($item['name']) && isset($item['value']))
-                ->map(fn ($item) => "{$item['name']}: {$item['value']}")
-                ->implode(', ');
+            if (setting('sage_50.remove_attribute_name')) {
+                $options = collect($item->options)
+                    ->filter(fn($item) => isset($item['value']))
+                    ->map(fn($item) => "{$item['value']}")
+                    ->implode(', ');
+            } else {
+                $options = collect($item->options)
+                    ->filter(fn ($item) => isset($item['name']) && isset($item['value']))
+                    ->map(fn ($item) => "{$item['name']}: {$item['value']}")
+                    ->implode(', ');
+            }
 
             $options = empty($options) ? '' : " ({$options})";
 

--- a/src/SageServiceProvider.php
+++ b/src/SageServiceProvider.php
@@ -62,6 +62,10 @@ class SageServiceProvider extends ModuleServiceProvider
             $group->boolean('product_detailed')
                 ->hint('Update products with information such as weight')
                 ->default(true);
+
+            $group->boolean('remove_attribute_name')
+                ->hint('Removes the attribute name from item description')
+                ->default(false);
         });
 
         AdminSlot::inject('orders.order.view.header.buttons', function ($data) {


### PR DESCRIPTION
## Description

Added a setting that will remove the attribute name from the item description. This was requested by Netball as they have multiple products exceeding the 60 character limit set by Sage, example - ASICS Academy 9 Soothing Sea Netball Trainers (Shoe Size: UK 7.5) - by removing the attribute name (Shoe Size) the character limit is met without losing any valuable information.

https://projects.techquity.co.uk/desk/tickets/6047222/messages

---
## Associated PR
N/A

---
## Checklist

N/A - tested locally.

- [ ] Changes have been tested in Development with no issues
- [ ] I have tested the checkout process on the Development site
- [ ] I have tested the changes on multiple browsers / devices (if applicable)

---



